### PR TITLE
persist oauth credentials

### DIFF
--- a/WFSAuth.js
+++ b/WFSAuth.js
@@ -2,11 +2,17 @@ import React, { Component } from 'react';
 import { Button, Text, TextInput, StyleSheet, View } from 'react-native';
 import { NavigationActions } from 'react-navigation';
 import * as db from './db';
+import config from './config.json';
 import * as exchange from './exchange';
 import { blue, orange, gray, darkGray } from './styles';
 
 class WFSAuth extends Component {
-  state = { user: '', password: '' };
+  state = {
+    user: '',
+    password: '',
+    clientId: config.client_id,
+    clientSecret: config.client_secret
+  };
 
   onChangeUser = user => {
     this.setState({ user });
@@ -16,10 +22,18 @@ class WFSAuth extends Component {
     this.setState({ password });
   };
 
+  onChangeClientId = clientId => {
+    this.setState({ clientId });
+  };
+
+  onChangeClientSecret = clientSecret => {
+    this.setState({ clientSecret });
+  };
+
   onPressAdd = async () => {
     const { navigate } = this.props.navigation;
     const { wfsUrl } = this.props.navigation.state.params;
-    const wfs = await db.saveExchange(wfsUrl, this.state.user, this.state.password);
+    const wfs = await db.saveExchange(wfsUrl, this.state.user, this.state.password, this.state.clientId, this.state.clientSecret);
     this.props.navigation.dispatch(
       NavigationActions.reset({
         index: 0,
@@ -72,6 +86,22 @@ class WFSAuth extends Component {
             autoCorrect={false}
             secureTextEntry
           />
+          <Text>OAuth Client ID:</Text>
+            <TextInput
+              style={styles.input}
+              onChangeText={this.onChangeClientId}
+              value={this.state.clientId}
+              autoCapitalize={'none'}
+              autoCorrect={false}
+            />
+            <Text>OAuth Client Secret:</Text>
+              <TextInput
+                style={styles.input}
+                onChangeText={this.onChangeClientSecret}
+                value={this.state.clientSecret}
+                autoCapitalize={'none'}
+                autoCorrect={false}
+              />
           <Button onPress={this.onPressAdd} title={'Add Credentials'} />
           <Button onPress={this.onPressAnon} title={'Continue without Credentials'} />
           <Button onPress={this.onPressCancel} title={'Cancel'} color={'#D9534F'} />

--- a/db.js
+++ b/db.js
@@ -12,6 +12,8 @@ const WFSSchema = {
     url: 'string',
     user: 'string',
     password: 'string',
+    clientId: 'string',
+    clientSecret: 'string',
     token: 'string',
     layers: { type: 'list', objectType: 'Layer' },
   },
@@ -53,7 +55,7 @@ export const monitor = () => {
   insertListener();
 };
 
-export const saveExchange = async (url, user, password) => {
+export const saveExchange = async (url, user, password, clientId, clientSecret) => {
   try {
     const token = await exchange.getToken(url, user, password);
     const layers = await exchange.getLayers(url, token);
@@ -64,6 +66,8 @@ export const saveExchange = async (url, user, password) => {
         url,
         user,
         password,
+        clientId,
+        clientSecret,
         token: JSON.stringify(token),
         layers: layers.map(l => ({
           id: uuid.v1(),


### PR DESCRIPTION
This PR saves the clientID and clientSecret in the realm db so they can be used in combination with the refresh token to automatically get a new `access_token` after it expires.  It also pulls defaults from a `config.json` file that can exist at the root of the project.